### PR TITLE
Improve avatar orientation and camera follow

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,5 @@
 import { Canvas } from "@react-three/fiber";
-import { Suspense, useEffect, useState } from "react";
+import { Suspense, useEffect, useState, useRef } from "react";
 import { KeyboardControls, OrbitControls } from "@react-three/drei";
 import { useAudio } from "./lib/stores/useAudio";
 import { useEducation } from "./lib/stores/useEducation";
@@ -8,12 +8,13 @@ import { useAvatarCustomization } from "./lib/stores/useAvatarCustomization";
 import "@fontsource/inter";
 
 // Import our game components
-import { SimpleAvatar } from "./components/SimpleAvatar";
+import { Avatar } from "./components/Avatar";
 import { GridWorld } from "./components/GridWorld";
 import { PrefabObjects } from "./components/PrefabObjects";
 import { Terrain } from "./components/Terrain";
 import { BuildSystem } from "./components/BuildSystem";
 import { GameUI } from "./components/UI/GameUI";
+import { FollowCamera } from "./components/FollowCamera";
 import { PREFAB_TYPES } from "./types/education";
 
 // Define control keys for the game
@@ -88,9 +89,11 @@ function App() {
     loadFromStorage 
   } = useWorldObjects();
   const { loadFromStorage: loadAvatarCustomization } = useAvatarCustomization();
-  
+
   // Avatar position state for camera following
   const [avatarPosition, setAvatarPosition] = useState<[number, number, number]>([0, 2, 0]);
+  const [avatarRotation, setAvatarRotation] = useState(0);
+  const controlsRef = useRef<OrbitControls | null>(null);
 
   // Load saved data on app start
   useEffect(() => {
@@ -122,6 +125,11 @@ function App() {
     setSelectedPrefab(null);
     
     console.log(`Placed ${prefabType.name} at position:`, position);
+  };
+
+  const handleAvatarMove = (pos: [number, number, number], rot: number) => {
+    setAvatarPosition(pos);
+    setAvatarRotation(rot);
   };
 
   return (
@@ -160,7 +168,7 @@ function App() {
             <GridWorld size={50} onGridClick={handleGridClick} />
             
             {/* Player Avatar */}
-            <SimpleAvatar onPositionChange={setAvatarPosition} />
+            <Avatar onMove={handleAvatarMove} />
             
             {/* Placed Objects */}
             <PrefabObjects />
@@ -169,9 +177,12 @@ function App() {
             <BuildSystem />
           </Suspense>
 
+          {/* Camera follow logic */}
+          <FollowCamera position={avatarPosition} rotation={avatarRotation} controls={controlsRef} />
+
           {/* Camera Controls - Enabled for 3rd person camera drag */}
           <OrbitControls
-            target={[avatarPosition[0], avatarPosition[1] + 1, avatarPosition[2]]}
+            ref={controlsRef}
             enablePan={false}
             enableZoom={true}
             enableRotate={true}

--- a/client/src/components/Avatar.tsx
+++ b/client/src/components/Avatar.tsx
@@ -1,5 +1,5 @@
-import { useRef, useEffect } from "react";
-import { useFrame, useThree } from "@react-three/fiber";
+import { useRef } from "react";
+import { useFrame } from "@react-three/fiber";
 import { useKeyboardControls, useGLTF } from "@react-three/drei";
 import { useAvatarCustomization } from "../lib/stores/useAvatarCustomization";
 import * as THREE from "three";
@@ -15,72 +15,69 @@ enum Controls {
 interface AvatarProps {
   position?: [number, number, number];
   onPositionChange?: (position: [number, number, number]) => void;
+  onMove?: (position: [number, number, number], rotation: number) => void;
 }
 
-export function Avatar({ position = [0, 0.5, 0], onPositionChange }: AvatarProps) {
+export function Avatar({ position = [0, 2, 0], onPositionChange, onMove }: AvatarProps) {
   const groupRef = useRef<THREE.Group>(null);
-  const [subscribe, getControls] = useKeyboardControls<Controls>();
-  const { camera } = useThree();
+  const [, getControls] = useKeyboardControls<Controls>();
   const { customization } = useAvatarCustomization();
-  
+
   // Load Nina 3D model with error handling
   const gltf = useGLTF('/models/nina_avatar.glb');
   const ninaModel = gltf?.scene;
-  
-  // Avatar movement state
-  const velocity = useRef(new THREE.Vector3());
-  const currentPosition = useRef(new THREE.Vector3(...position));
-  const rotation = useRef(0);
-  const cameraOffset = useRef(new THREE.Vector3(0, 8, 10));
-  const cameraTarget = useRef(new THREE.Vector3());
-  
-  // Initialize position
-  useEffect(() => {
-    if (groupRef.current) {
-      groupRef.current.position.set(...position);
-      currentPosition.current.set(...position);
-    }
-  }, [position]);
-  
-  // Working movement system
+
+  // Simple position/rotation state (similar to SimpleAvatar)
+  const positionRef = useRef<[number, number, number]>(position);
+  // Current rotation in radians, 0 facing positive Z
+  const rotationRef = useRef(0);
+
   useFrame((state, delta) => {
     if (!groupRef.current) return;
-    
+
     const controls = getControls();
-    const speed = 15;
-    
-    // Get current position from mesh
-    let x = groupRef.current.position.x;
-    let z = groupRef.current.position.z;
-    let rot = groupRef.current.rotation.y;
-    
-    // Handle rotation
-    if (controls.leftward) {
-      rot += 4 * delta;
-    }
-    if (controls.rightward) {
-      rot -= 4 * delta;
-    }
-    
-    // Handle movement in facing direction
-    if (controls.forward) {
+    const speed = 10;
+
+    let [x, y, z] = positionRef.current;
+    let rot = rotationRef.current;
+
+    // Determine intended direction based on pressed keys
+    let dirX = 0;
+    let dirZ = 0;
+    if (controls.forward) dirZ += 1;
+    if (controls.backward) dirZ -= 1;
+    if (controls.leftward) dirX -= 1;
+    if (controls.rightward) dirX += 1;
+
+    // If any movement key pressed, face that direction instantly
+    let bounce = 0;
+    if (dirX !== 0 || dirZ !== 0) {
+      const targetRot = Math.atan2(dirX, dirZ);
+      rot = targetRot;
       x += Math.sin(rot) * speed * delta;
       z += Math.cos(rot) * speed * delta;
+      // simple walking bounce effect
+      bounce = Math.sin(state.clock.elapsedTime * 8) * 0.1;
     }
-    if (controls.backward) {
-      x -= Math.sin(rot) * speed * delta;
-      z -= Math.cos(rot) * speed * delta;
-    }
-    
-    // Update position with higher Y to clear terrain obstacles
-    groupRef.current.position.set(x, 10, z);
+
+    positionRef.current = [x, y, z];
+    rotationRef.current = rot;
+
+    groupRef.current.position.set(x, y + bounce, z);
     groupRef.current.rotation.y = rot;
-    currentPosition.current.set(x, 10, z);
-    rotation.current = rot;
-    
-    // Update camera target
-    if (onPositionChange) {
-      onPositionChange([x, 2, z]);
+
+    if (
+      onPositionChange &&
+      (controls.forward || controls.backward || controls.leftward || controls.rightward)
+    ) {
+      onPositionChange([x, y, z]);
+    }
+
+    if (
+      onMove &&
+      (controls.forward || controls.backward || controls.leftward || controls.rightward)
+    ) {
+      onMove([x, y, z], rot);
     }
   });
   
@@ -88,9 +85,9 @@ export function Avatar({ position = [0, 0.5, 0], onPositionChange }: AvatarProps
     <group ref={groupRef}>
       {/* 3D Nina Model with fallback */}
       {ninaModel ? (
-        <primitive 
-          object={ninaModel.clone()} 
-          scale={[2.5, 2.5, 2.5]} 
+        <primitive
+          object={ninaModel.clone()}
+          scale={[2.5, 2.5, 2.5]}
           position={[0, -0.9, 0]}
           castShadow
         />

--- a/client/src/components/FollowCamera.tsx
+++ b/client/src/components/FollowCamera.tsx
@@ -1,0 +1,30 @@
+import { useThree, useFrame } from "@react-three/fiber";
+import { OrbitControls } from "@react-three/drei";
+import { MutableRefObject } from "react";
+import * as THREE from "three";
+
+interface FollowCameraProps {
+  position: [number, number, number];
+  rotation: number;
+  controls: MutableRefObject<OrbitControls | null>;
+}
+
+export function FollowCamera({ position, rotation, controls }: FollowCameraProps) {
+  const { camera } = useThree();
+  const offset = new THREE.Vector3(0, 8, 12);
+
+  useFrame(() => {
+    const [x, y, z] = position;
+    const rotatedOffset = offset.clone().applyAxisAngle(new THREE.Vector3(0, 1, 0), rotation);
+    camera.position.set(x - rotatedOffset.x, y + rotatedOffset.y, z - rotatedOffset.z);
+
+    if (controls.current) {
+      controls.current.target.set(x, y + 1, z);
+      controls.current.update();
+    }
+  });
+
+  return null;
+}
+
+


### PR DESCRIPTION
## Summary
- extend `Avatar` component with `onMove` callback
- remove rotation offset on Nina model
- add `FollowCamera` component to keep camera behind the avatar
- connect new camera follow logic in `App`

## Testing
- `npm run check` *(fails: casing conflicts and missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_685098bf10108325a0097f6c42dccf07